### PR TITLE
Allow unauthenticated push endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Crybotix2
 
-The application exposes an API endpoint at `/api/ui/push`.
-Configure Dify to POST trade data to this route so the UI can be kept up to date.
+The application exposes an unauthenticated API endpoint at `/api/ui/push`.
+Any client can POST trade data to this route so the UI can be kept up to date.
 
 ```json
 {

--- a/app/api/ui/push/route.ts
+++ b/app/api/ui/push/route.ts
@@ -7,13 +7,6 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
-  const ingestToken = process.env.INGEST_TOKEN;
-  const authHeader = req.headers.get("Authorization");
-
-  if (!authHeader || authHeader !== `Bearer ${ingestToken}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   try {
     const data = await req.json();
     tradeSchema.parse(data);


### PR DESCRIPTION
## Summary
- Remove ingest token authorization from `/api/ui/push` POST handler so any client can submit data
- Document that `/api/ui/push` is unauthenticated and open to all clients

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c520d27244832aa32e86e80a0064a6