### PR TITLE
feat: add centralized error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .next/
 .env
 .DS_Store
+logs/

--- a/app/api/input/route.ts
+++ b/app/api/input/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
+import { logError } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -30,11 +31,11 @@ export async function POST(req: Request) {
     const form = await req.formData();
     const image = form.get("image");
     if (!image || !(image instanceof File)) {
-      console.error("INPUT: no image or wrong field type");
+      logError({ name: "INPUT", message: "no image or wrong field type" });
       return NextResponse.json({ error: "No image" }, { status: 400 });
     }
     if (!process.env.OPENAI_API_KEY) {
-      console.error("INPUT: OPENAI_API_KEY missing");
+      logError({ name: "INPUT", message: "OPENAI_API_KEY missing" });
       return NextResponse.json({ error: "Server error" }, { status: 500 });
     }
 
@@ -69,13 +70,7 @@ export async function POST(req: Request) {
     }
     return NextResponse.json(json);
   } catch (err: any) {
-    console.error("INPUT ERROR:", {
-      name: err?.name,
-      message: err?.message,
-      status: err?.status,
-      data: err?.response?.data,
-      stack: err?.stack,
-    });
+    logError(err);
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
 }

--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
+import { logError } from "@/lib/logger";
 
 export async function POST(req: Request) {
-  const data = await req.json();
-  return NextResponse.json(data);
+  try {
+    const data = await req.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    logError(err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
 }

--- a/app/api/ui/push/route.ts
+++ b/app/api/ui/push/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { ZodError } from "zod";
 import { tradeSchema } from "@/lib/trade";
+import { logError } from "@/lib/logger";
 
 export async function GET() {
   return NextResponse.json({ status: "public ok" });
@@ -15,6 +16,7 @@ export async function POST(req: Request) {
     if (err instanceof ZodError) {
       return NextResponse.json({ ok: false, error: err.errors }, { status: 400 });
     }
+    logError(err);
     return NextResponse.json({ ok: false }, { status: 500 });
   }
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,45 @@
+import fs from "fs";
+import path from "path";
+
+const logDir = path.join(process.cwd(), "logs");
+const logFile = path.join(logDir, "error.log");
+
+function ensureLogFile() {
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+}
+
+export function logError(err: any) {
+  ensureLogFile();
+  const entry = {
+    timestamp: new Date().toISOString(),
+    name: err?.name,
+    message: err?.message,
+    status: err?.status,
+    data: err?.response?.data,
+    stack: err?.stack,
+  };
+  try {
+    fs.appendFileSync(logFile, JSON.stringify(entry) + "\n");
+  } catch (writeErr) {
+    console.error("LOGGER: failed to write error log", writeErr);
+  }
+  console.error("ERROR:", entry);
+}
+
+export function logInfo(message: string, meta: Record<string, any> = {}) {
+  ensureLogFile();
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level: "info",
+    message,
+    ...meta,
+  };
+  try {
+    fs.appendFileSync(logFile, JSON.stringify(entry) + "\n");
+  } catch (writeErr) {
+    console.error("LOGGER: failed to write info log", writeErr);
+  }
+  console.log("INFO:", entry);
+}


### PR DESCRIPTION
## Summary
- add reusable file and console logger
- log server errors in all API routes
- ignore generated log files

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5b0fbbe18832aa265ddd9d8788eca