### PR TITLE
fix: update response formatting for openai api

### DIFF
--- a/app/api/input/route.ts
+++ b/app/api/input/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: Request) {
           ] as any,
         },
       ],
-      response_format: { type: "json_schema", json_schema: schema },
+      text: { format: { type: "json_schema", json_schema: schema } },
       reasoning_effort: "medium",
       verbosity: "medium",
     } as any);


### PR DESCRIPTION
## Summary
- use `text.format` instead of deprecated `response_format` when calling OpenAI Responses API

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5b981e140832a8faeac47dc9e2290